### PR TITLE
Fix "TypeError: Reduce of empty array with no initial value"

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,15 @@
 {
-    "presets": ["es2015"],
-    "plugins": ["add-module-exports"]
+  "presets": [
+    "es2015"
+  ],
+  "plugins": [
+    "add-module-exports"
+  ],
+  "env": {
+    "development": {
+      "presets": [
+        "power-assert"
+      ]
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -9,22 +9,23 @@
   },
   "dependencies": {
     "kuromojin": "^1.1.0",
-    "sentence-splitter": "^1.2.0",
+    "sentence-splitter": "^2.0.0",
     "textlint-rule-helper": "^1.1.5",
     "textlint-util-to-string": "^1.2.0"
   },
   "devDependencies": {
     "babel-cli": "^6.5.1",
-    "babel-plugin-add-module-exports": "^0.1.2",
+    "babel-plugin-add-module-exports": "^0.2.0",
     "babel-preset-es2015": "^6.5.0",
-    "espower-babel": "^4.0.1",
+    "babel-preset-power-assert": "^1.0.0",
+    "babel-register": "^6.8.0",
     "mocha": "^2.4.5",
-    "power-assert": "^1.2.0",
-    "textlint": "^5.2.1",
-    "textlint-tester": "^0.4.1"
+    "power-assert": "^1.4.0",
+    "textlint": "^6.6.0",
+    "textlint-tester": "^1.2.0"
   },
   "scripts": {
-    "build": "babel src --out-dir lib --source-maps",
+    "build": "NODE_ENV=production babel src --out-dir lib --source-maps",
     "watch": "babel src --out-dir lib --watch --source-maps",
     "prepublish": "npm run --if-present build",
     "test": "mocha",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,1 @@
---compilers js:espower-babel/guess
+--compilers js:babel-register

--- a/test/no-doubled-conjunction.js
+++ b/test/no-doubled-conjunction.js
@@ -1,11 +1,11 @@
-import assert from "power-assert";
 import rule from "../src/no-doubled-conjunction";
 import TextLintTester from "textlint-tester";
 var tester = new TextLintTester();
 tester.run("no-doubled-conjunction", rule, {
     valid: [
         "朝起きた。そして、夜に寝た。",
-        "そして朝起きた。けれど昼は仕事をした。そして夜に寝た。"
+        "そして朝起きた。けれど昼は仕事をした。そして夜に寝た。",
+        "``" // empty Paragraph
     ],
     invalid: [
       {

--- a/test/no-doubled-conjunction.js
+++ b/test/no-doubled-conjunction.js
@@ -5,7 +5,8 @@ tester.run("no-doubled-conjunction", rule, {
     valid: [
         "朝起きた。そして、夜に寝た。",
         "そして朝起きた。けれど昼は仕事をした。そして夜に寝た。",
-        "``" // empty Paragraph
+        "``", // empty Paragraph,
+        "![](path/to/image.png)"// empty image label
     ],
     invalid: [
       {


### PR DESCRIPTION
This pull request contain these changes:

- Update dependencies/devDependencies
     - refs: http://efcl.info/2016/04/14/espower-babel-is-deprecated/
- Fix "TypeError: Reduce of empty array with no initial value"
     - refs: http://azu.github.io/slide/JSGohan/reduce.html

```js
[].reduce()
// emptryArray.reduce() throw error in JavaScript
```

Lint follwing text with "no-doubled-conjunction" rule.


```
![](path/to/image.png)"
```

### Expected

No Error

### Actual

Throw Error

```
TypeError: Reduce of empty array with no initial value
    at Array.reduce (native)
    at no-doubled-conjunction.js:39:48
```